### PR TITLE
Add request method for dynamic decision of what HTTP method to use

### DIFF
--- a/lib/simplehttp.ex
+++ b/lib/simplehttp.ex
@@ -25,10 +25,14 @@ defmodule SimpleHttp do
 
   Enum.each(methods, fn method ->
     def unquote(:"#{method}")(url, args \\ []) do
-      create_request(unquote(String.to_atom(method)), url, args)
-      |> execute
+      request(String.to_atom(unquote(method)), url, args)
     end
   end)
+
+  def request(method, url, args \\ []) do
+    create_request(method, url, args)
+    |> execute
+  end
 
   @doc """
     Before you use this module you SHOULD call SimpleHttp.start

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule SimpleHttp.Mixfile do
   defp deps do
     [
       {:ex_doc, ">= 0.0.0", only: :dev},
-      {:cowboy, ">= 1.0.4", only: :test},
+      {:cowboy, "~> 1.0.4", only: :test},
       {:plug, ">= 1.2.0", only: :test},
       {:excoveralls, github: "parroty/excoveralls", only: :test}
     ]

--- a/test/simplehttp_test.exs
+++ b/test/simplehttp_test.exs
@@ -72,8 +72,28 @@ defmodule SimpleHttpTest do
     assert response.body == "ok"
   end
 
+  test "get via request method" do
+    assert {:ok, response } = SimpleHttp.request :get, "http://localhost:4000"
+    assert response.__struct__ == SimpleHttp.Response
+    assert response.body == "ok"
+  end
+
   test "simple post request" do
     assert {:ok, response } = SimpleHttp.post "http://localhost:4000", [
+      params: [
+        title: "title is present here",
+        message: "hello world!"
+      ],
+      content_type: "application/x-www-form-urlencoded",
+      timeout: 1000,
+      connect_timeout: 1000
+    ]
+    assert response.__struct__ == SimpleHttp.Response
+    assert response.body == "ok"
+  end
+
+  test "post via request method" do
+    assert {:ok, response } = SimpleHttp.request :post, "http://localhost:4000", [
       params: [
         title: "title is present here",
         message: "hello world!"
@@ -100,8 +120,28 @@ defmodule SimpleHttpTest do
     assert response.body == "ok"
   end
 
+  test "put via request method" do
+    assert {:ok, response } = SimpleHttp.request :put, "http://localhost:4000/users/1", [
+      params: [
+        title: "title is present here",
+        message: "hello world!"
+      ],
+      content_type: "application/x-www-form-urlencoded",
+      timeout: 1000,
+      connect_timeout: 1000
+    ]
+    assert response.__struct__ == SimpleHttp.Response
+    assert response.body == "ok"
+  end
+
   test "simple delete request" do
     assert {:ok, response } = SimpleHttp.delete "http://localhost:4000"
+    assert response.__struct__ == SimpleHttp.Response
+    assert response.body == "ok"
+  end
+
+  test "delete via request method" do
+    assert {:ok, response } = SimpleHttp.request :delete, "http://localhost:4000"
     assert response.__struct__ == SimpleHttp.Response
     assert response.body == "ok"
   end


### PR DESCRIPTION
Hi! First of all, thank you for this nice little library!

While using it, I faced situation where I had HTTP method set dynamically based on the data coming from command line option. Much like in `httpc`, I wanted to set appropriate atom and use it, but it turned out to be impossible. This is my proposition to bring back this feature and be able to call something like `SimpleHttp.request(:get, "http://localhost:4000")`.

Let me know what you think. 